### PR TITLE
ShipView: hide away undefineds if ship unbooted

### DIFF
--- a/ui/src/components/ShipView.svelte
+++ b/ui/src/components/ShipView.svelte
@@ -243,7 +243,7 @@
                     class="inline"
                   >
                     Key Revision:
-                    {pointInfo.life}
+                    {pointInfo.life || "n/a"}
                   </TooltipAndDocLink>
                 </p>
                 <p>
@@ -253,7 +253,7 @@
                     class="inline"
                   >
                     Factory Resets:
-                    {pointInfo.rift}
+                    {pointInfo.rift || "n/a"}
                   </TooltipAndDocLink>
                 </p>
                 {#if pointInfo.proxies}


### PR DESCRIPTION
Now looks like this:

<img width="284" alt="image" src="https://user-images.githubusercontent.com/20846414/167333310-2fddaf5d-a6ca-4ac5-b615-dd82d116088b.png">
